### PR TITLE
[#56] 서버 시작시 테이블명 리스트 Load하는 스텝 추가

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -85,6 +85,12 @@ impl DBEngine {
             disktable_manager
         };
 
+        // 7. Load table list
+        {
+            let table_list = disktable_manager.list_tables().await?;
+            memtable_manager.load_table_list(table_list).await?;
+        }
+
         let manager = Self {
             system_info,
             base_path: base_path.clone(),

--- a/src/memtable/mod.rs
+++ b/src/memtable/mod.rs
@@ -40,6 +40,14 @@ impl MemtableManager {
         }
     }
 
+    pub async fn load_table_list(&self, table_list: Vec<String>) -> errors::Result<()> {
+        for table in table_list {
+            self.create_table(&table).await?;
+        }
+
+        Ok(())
+    }
+
     pub async fn list_tables(&self) -> errors::Result<Vec<String>> {
         let memtable_map = self.memtable_map.read().await;
 


### PR DESCRIPTION
resolved: #56

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리즈 노트

* **새로운 기능**
  * 데이터베이스 시작 시 디스크의 테이블 목록이 자동으로 메모리에 동기화됩니다.
  * 여러 테이블을 한 번에 효율적으로 로드할 수 있는 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->