### PR TITLE
[#118] memtable flush시 테이블 정보 누락되는 문제, delete 동작 오류 수정

### DIFF
--- a/src/memtable/mod.rs
+++ b/src/memtable/mod.rs
@@ -309,10 +309,7 @@ impl MemtableManager {
             Some(memtable) => {
                 let mut memtable_lock = memtable.lock().await;
 
-                match memtable_lock.delete(&key) {
-                    Some(_) => (),
-                    None => return Err(Errors::ValueNotFound(format!("Key not found: {}", key))),
-                }
+                let _ = memtable_lock.delete(&key);
 
                 Ok(())
             }


### PR DESCRIPTION
resolved: #118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 데이터베이스 복구 중 삭제 작업의 오류 처리 개선 - 복구 과정에서 중요하지 않은 오류는 무시하고 진행
  * 메모리 플러시 작업 중 데이터 일관성 유지 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->